### PR TITLE
fix(jira-cmd): add createmeta capability detection for Jira 9+/10

### DIFF
--- a/lib/jira/create.js
+++ b/lib/jira/create.js
@@ -27,7 +27,7 @@ define([
 
       if(answer || answer===false){
         return callback(answer);
-      }      
+      }
       if (values && values.length > 0) {
         for (i; i < values.length; i++) {
           if (that.isSubTask) {
@@ -231,23 +231,112 @@ define([
       });
     },
 
+    // Capability-detect meta loader:
+    // - Try Jira 8.4+ project-scoped createmeta endpoints first.
+    // - If they 404, fall back to legacy global createmeta.
     getMeta: function (callback) {
-      this.query = 'rest/api/2/issue/createmeta';
       var cachedRes = cache.getSync('meta', 'project', 1000*60*60*24*7);
-      if(cachedRes){
+      if (cachedRes) {
         return callback(cachedRes);
       }
-      request
-        .get(config.auth.url + this.query)
-        .set('Content-Type', 'application/json')
-        .set('Authorization', Auth.getAuthorizationHeader())
-        .end(function (res) {
-          if (!res.ok) {
-            return console.log((res.body.errorMessages || [res.error]).join('\n'));
-          }
-          cache.set('meta', 'project', res.body.projects);       
-          callback(res.body.projects);
-        });
+
+      var baseUrl = config.auth.url;
+      var authHeader = Auth.getAuthorizationHeader();
+
+      var useLegacy = function () {
+        request
+          .get(baseUrl + 'rest/api/2/issue/createmeta')
+          .set('Content-Type', 'application/json')
+          .set('Authorization', authHeader)
+          .end(function (res) {
+            if (!res.ok) {
+              return console.log((res.body && res.body.errorMessages ? res.body.errorMessages : [res.error]).join('\n'));
+            }
+            cache.set('meta', 'project', res.body.projects);
+            callback(res.body.projects);
+          });
+      };
+
+      var useNew = function () {
+        request
+          .get(baseUrl + 'rest/api/2/project')
+          .set('Content-Type', 'application/json')
+          .set('Authorization', authHeader)
+          .end(function (res) {
+            if (!res.ok) {
+              return console.log((res.body && res.body.errorMessages ? res.body.errorMessages : [res.error]).join('\n'));
+            }
+
+            var rawProjects = res.body || [];
+
+            async.mapLimit(rawProjects, 5, function (p, done) {
+              request
+                .get(baseUrl + 'rest/api/2/issue/createmeta/' + p.key + '/issuetypes')
+                .set('Content-Type', 'application/json')
+                .set('Authorization', authHeader)
+                .end(function (r2) {
+                  var status = r2 && (r2.status || (r2.res && r2.res.statusCode));
+
+                  if (!r2.ok) {
+                    // If the new endpoint is not available, fall back to legacy.
+                    if (status === 404) {
+                      var err = new Error('NEEDS_LEGACY_CREATEMETA');
+                      err.code = 'NEEDS_LEGACY_CREATEMETA';
+                      return done(err);
+                    }
+
+                    return done(null, {
+                      id: p.id,
+                      key: p.key,
+                      name: p.name,
+                      issuetypes: []
+                    });
+                  }
+
+                  // Normalize response shape for issuetypes
+                  var body = r2.body || {};
+                  var types = [];
+
+                  if (Array.isArray(body)) {
+                    types = body;
+                  } else if (Array.isArray(body.issuetypes)) {
+                    types = body.issuetypes;
+                  } else if (Array.isArray(body.values)) {
+                    types = body.values;
+                  } else if (body.values && Array.isArray(body.values.values)) {
+                    types = body.values.values;
+                  }
+
+                  var normalizedTypes = (types || []).map(function (t) {
+                    return {
+                      id: t.id,
+                      name: t.name,
+                      subtask: t.subtask
+                    };
+                  });
+
+                  done(null, {
+                    id: p.id,
+                    key: p.key,
+                    name: p.name,
+                    issuetypes: normalizedTypes
+                  });
+                });
+            }, function (err, projects) {
+              if (err && err.code === 'NEEDS_LEGACY_CREATEMETA') {
+                return useLegacy();
+              }
+              if (err) {
+                return console.log(err.message || err);
+              }
+
+              cache.set('meta', 'project', projects);
+              callback(projects);
+            });
+          });
+      };
+
+      useNew();
     },
 
     getPriorities: function (callback) {
@@ -256,7 +345,7 @@ define([
       if(cachedRes){
         return callback(cachedRes);
       }
-      
+
       request
         .get(config.auth.url + this.query)
         .set('Content-Type', 'application/json')
@@ -265,7 +354,7 @@ define([
           if (!res.ok) {
             return console.log(res.body.errorMessages.join('\n'));
           }
-          cache.set('meta', 'priorities', res.body);       
+          cache.set('meta', 'priorities', res.body);
           callback(res.body);
         });
     },


### PR DESCRIPTION
Replace legacy global createmeta usage with a capability-detect flow. Try project-scoped createmeta issuetypes endpoints first and fall back to /rest/api/2/issue/createmeta on 404, preserving backwards compatibility with Jira 8.x while restoring create on Jira 9+.

This prevents "Issue Does Not Exist" errors caused by createmeta API removed by Atlassian post version 9 .